### PR TITLE
feat: add configurable ASX support

### DIFF
--- a/Experiment Details/Using Scripts.md
+++ b/Experiment Details/Using Scripts.md
@@ -3,14 +3,16 @@
 **Note: NONE OF THE PROMPTS ARE AUTOMATED, MANUAL UPDATES AND DEEP RESEARCH IS REQUIRED**
 ## Generate_Graph.py
 
-Pretty simple — it grabs the daily logs from `'chatgpt_portfolio_update.csv'` and then plots the results alongside S&P 500 returns (adjusted for $100).  
-To run, just make sure there's data in `'chatgpt_portfolio_update.csv'`, then run the script to generate the plot.
+Pretty simple — it grabs the daily logs from `'chatgpt_portfolio_update.csv'` and then plots the results alongside a benchmark index (default S&P 500, ticker `^SPX`).
+To run, just make sure there's data in `'chatgpt_portfolio_update.csv'`, then run the script to generate the plot. Use `--benchmark-index` to compare against another market such as the S&P/ASX 200 (`^AXJO`).
 
 ---
 
 ## Trading_Script.py
 
 The trading script tracks positions, logs trades, and prints daily results.
+
+Set `DEFAULT_SUFFIX` in the script to automatically append an exchange suffix to tickers. For example, `DEFAULT_SUFFIX = ".AX"` lets you enter `BHP` and have it logged as `BHP.AX` for the Australian Securities Exchange.
 
 ### 1. Daily Results
 
@@ -19,24 +21,17 @@ If it's not a trading day, it will use data from the previous day.
 It will also print the updated portfolio and cash. **If any manual trades were made, be sure to copy both and update the code.**
 By default the function also reports the Russell 2000 (`^RUT`), IWO, and XBI for comparison.
 
-To add additional tickers without modifying the portfolio:
-
-Before:
+You can override these benchmarks, the comparison index, and the risk-free rate:
 
 ```python
-# say we want data from SPY
-for stock in chatgpt_portfolio + [{"ticker": "^RUT"}] + [{"ticker": "IWO"}] + [{"ticker": "XBI"}]:
-    print(stock)
+daily_results(
+    chatgpt_portfolio,
+    cash,
+    benchmarks=["^AXJO"],
+    comparison_index="^AXJO",
+    rf_annual=0.04,
+)
 ```
-
-After:
-
-```python
-for stock in chatgpt_portfolio + [{"ticker": "^RUT"}] + [{"ticker": "IWO"}] + [{"ticker": "XBI"}] + [{"ticker": "SPY"}]:
-    print(stock)
-```
-That's it!
-
 ### Process Portfolio
 Handles stop-losses, updates `'chatgpt_portfolio_update.csv'`, and now prompts for manual trades before processing.
 

--- a/Scripts and CSV Files/Trading_Script.py
+++ b/Scripts and CSV Files/Trading_Script.py
@@ -13,6 +13,11 @@ import pandas as pd
 import yfinance as yf
 from typing import cast
 
+# Regional defaults
+# Set ``DEFAULT_SUFFIX`` to ".AX" when working with Australian tickers
+DEFAULT_SUFFIX = ""
+DEFAULT_BENCHMARKS = ["^RUT", "IWO", "XBI"]
+
 # Shared file locations
 DATA_DIR = "Scripts and CSV Files"
 PORTFOLIO_CSV = f"{DATA_DIR}/chatgpt_portfolio_update.csv"
@@ -20,6 +25,13 @@ TRADE_LOG_CSV = f"{DATA_DIR}/chatgpt_trade_log.csv"
 
 # Today's date reused across logs
 today = datetime.today().strftime("%Y-%m-%d")
+
+
+def apply_suffix(ticker: str) -> str:
+    """Append ``DEFAULT_SUFFIX`` when the ticker lacks an exchange suffix."""
+    if DEFAULT_SUFFIX and "." not in ticker and not ticker.startswith("^"):
+        return f"{ticker}{DEFAULT_SUFFIX}"
+    return ticker
 
 
 def process_portfolio(portfolio: pd.DataFrame, starting_cash: float) -> pd.DataFrame:
@@ -41,7 +53,7 @@ def process_portfolio(portfolio: pd.DataFrame, starting_cash: float) -> pd.DataF
         ).strip().lower()
         if action == "b":
             try:
-                ticker = input("Enter ticker symbol: ").strip().upper()
+                ticker = apply_suffix(input("Enter ticker symbol: ").strip().upper())
                 shares = float(input("Enter number of shares: "))
                 buy_price = float(input("Enter buy price: "))
                 stop_loss = float(input("Enter stop loss: "))
@@ -56,7 +68,7 @@ def process_portfolio(portfolio: pd.DataFrame, starting_cash: float) -> pd.DataF
             continue
         if action == "s":
             try:
-                ticker = input("Enter ticker symbol: ").strip().upper()
+                ticker = apply_suffix(input("Enter ticker symbol: ").strip().upper())
                 shares = float(input("Enter number of shares to sell: "))
                 sell_price = float(input("Enter sell price: "))
                 if shares <= 0 or sell_price <= 0:
@@ -71,7 +83,7 @@ def process_portfolio(portfolio: pd.DataFrame, starting_cash: float) -> pd.DataF
         break
 
     for _, stock in portfolio.iterrows():
-        ticker = stock["ticker"]
+        ticker = apply_suffix(stock["ticker"])
         shares = int(stock["shares"])
         cost = stock["buy_price"]
         stop = stock["stop_loss"]
@@ -297,12 +309,20 @@ def log_manual_sell(
     return cash, chatgpt_portfolio
 
 
-def daily_results(chatgpt_portfolio: pd.DataFrame, cash: float) -> None:
+def daily_results(
+    chatgpt_portfolio: pd.DataFrame,
+    cash: float,
+    benchmarks: list[str] | None = None,
+    rf_annual: float = 0.045,
+    comparison_index: str = "^SPX",
+) -> None:
     """Print daily price updates and performance metrics."""
     if isinstance(chatgpt_portfolio, pd.DataFrame):
         portfolio_dict = chatgpt_portfolio.to_dict(orient="records")
+    if benchmarks is None:
+        benchmarks = DEFAULT_BENCHMARKS
     print(f"prices and updates for {today}")
-    for stock in portfolio_dict + [{"ticker": "^RUT"}] + [{"ticker": "IWO"}] + [{"ticker": "XBI"}]:
+    for stock in portfolio_dict + [{"ticker": b} for b in benchmarks]:
         ticker = stock["ticker"]
         try:
             data = yf.download(ticker, period="2d", progress=False)
@@ -338,8 +358,7 @@ def daily_results(chatgpt_portfolio: pd.DataFrame, cash: float) -> None:
     # Number of total trading days
     n_days = len(chatgpt_totals)
 
-    # Risk-free return over total trading period (assuming 4.5% risk-free rate)
-    rf_annual = 0.045
+    # Risk-free return over total trading period
     rf_period = (1 + rf_annual) ** (n_days / 252) - 1
 
     # Standard deviation of daily returns
@@ -355,17 +374,24 @@ def daily_results(chatgpt_portfolio: pd.DataFrame, cash: float) -> None:
     print(f"Total Sharpe Ratio over {n_days} days: {sharpe_total:.4f}")
     print(f"Total Sortino Ratio over {n_days} days: {sortino_total:.4f}")
     print(f"Latest ChatGPT Equity: ${final_equity:.2f}")
-    # Get S&P 500 data
-    spx = yf.download("^SPX", start="2025-06-27", end=final_date + pd.Timedelta(days=1), progress=False)
-    spx = cast(pd.DataFrame, spx)
-    spx = spx.reset_index()
+
+    # Get comparison index data
+    start_date = chatgpt_totals["Date"].min()
+    index_df = yf.download(
+        comparison_index,
+        start=start_date,
+        end=final_date + pd.Timedelta(days=1),
+        progress=False,
+    )
+    index_df = cast(pd.DataFrame, index_df)
+    index_df = index_df.reset_index()
 
     # Normalize to $100
-    initial_price = spx["Close"].iloc[0].item()
-    price_now = spx["Close"].iloc[-1].item()
+    initial_price = index_df["Close"].iloc[0].item()
+    price_now = index_df["Close"].iloc[-1].item()
     scaling_factor = 100 / initial_price
-    spx_value = price_now * scaling_factor
-    print(f"$100 Invested in the S&P 500: ${spx_value:.2f}")
+    index_value = price_now * scaling_factor
+    print(f"$100 Invested in {comparison_index}: ${index_value:.2f}")
     print(f"today's portfolio: {chatgpt_portfolio}")
     print(f"cash balance: {cash}")
 

--- a/Start Your Own/Generate_Graph.py
+++ b/Start Your Own/Generate_Graph.py
@@ -1,8 +1,9 @@
-"""Plot ChatGPT portfolio performance against the S&P 500.
 
-The script loads logged portfolio equity, fetches S&P 500 data, and
-renders a comparison chart. Core behaviour remains unchanged; the code
-is simply reorganised and commented for clarity.
+"""Plot ChatGPT portfolio performance against a benchmark index.
+
+The script loads logged portfolio equity, fetches comparison index data,
+and renders a chart. Core behaviour remains unchanged; the code is simply
+reorganised and commented for clarity.
 """
 
 import argparse
@@ -44,23 +45,28 @@ def load_portfolio_details(
     return pd.concat([baseline_row, chatgpt_totals], ignore_index=True).sort_values("Date")
 
 
-def download_sp500(start_date: pd.Timestamp, end_date: pd.Timestamp) -> pd.DataFrame:
-    """Download S&P 500 prices and normalise to a $100 baseline."""
-    sp500 = yf.download(
-        "^SPX", start=start_date, end=end_date + pd.Timedelta(days=1), progress=False
+def download_index(
+    ticker: str, start_date: pd.Timestamp, end_date: pd.Timestamp
+) -> pd.DataFrame:
+    """Download index prices and normalise to a $100 baseline."""
+    idx = yf.download(
+        ticker, start=start_date, end=end_date + pd.Timedelta(days=1), progress=False
     )
-    sp500 = cast(pd.DataFrame, sp500)
-    sp500 = sp500.reset_index()
-    if isinstance(sp500.columns, pd.MultiIndex):
-        sp500.columns = sp500.columns.get_level_values(0)
-    spx_27_price = 6173.07
-    scaling_factor = 100 / spx_27_price
-    sp500["SPX Value ($100 Invested)"] = sp500["Close"] * scaling_factor
-    return sp500
+    idx = cast(pd.DataFrame, idx)
+    idx = idx.reset_index()
+    if isinstance(idx.columns, pd.MultiIndex):
+        idx.columns = idx.columns.get_level_values(0)
+    initial_price = idx["Close"].iloc[0]
+    scaling_factor = 100 / initial_price
+    idx[f"{ticker} Value ($100 Invested)"] = idx["Close"] * scaling_factor
+    return idx
 
 
 def main(
-    baseline_equity: float, start_date: pd.Timestamp | None, end_date: pd.Timestamp | None
+    baseline_equity: float,
+    start_date: pd.Timestamp | None,
+    end_date: pd.Timestamp | None,
+    benchmark_index: str,
 ) -> None:
     """Generate and display the comparison graph."""
     chatgpt_totals = load_portfolio_details(baseline_equity, start_date)
@@ -70,7 +76,7 @@ def main(
     if end_date is None:
         end_date = chatgpt_totals["Date"].max()
 
-    sp500 = download_sp500(start_date, end_date)
+    benchmark_df = download_index(benchmark_index, start_date, end_date)
 
     plt.figure(figsize=(10, 6))
     plt.style.use("seaborn-v0_8-whitegrid")
@@ -83,9 +89,9 @@ def main(
         linewidth=2,
     )
     plt.plot(
-        sp500["Date"],
-        sp500["SPX Value ($100 Invested)"],
-        label="S&P 500 ($100 Invested)",
+        benchmark_df["Date"],
+        benchmark_df[f"{benchmark_index} Value ($100 Invested)"],
+        label=f"{benchmark_index} ($100 Invested)",
         marker="o",
         color="orange",
         linestyle="--",
@@ -94,7 +100,7 @@ def main(
 
     final_date = chatgpt_totals["Date"].iloc[-1]
     final_chatgpt = float(chatgpt_totals["Total Equity"].iloc[-1])
-    final_spx = sp500["SPX Value ($100 Invested)"].iloc[-1]
+    final_spx = benchmark_df[f"{benchmark_index} Value ($100 Invested)"].iloc[-1]
 
     plt.text(
         final_date, final_chatgpt + 0.3, f"+{final_chatgpt - baseline_equity:.1f}%", color="blue", fontsize=9
@@ -102,7 +108,7 @@ def main(
     plt.text(
         final_date, final_spx + 0.9, f"+{final_spx - 100:.1f}%", color="orange", fontsize=9
     )
-    plt.title("ChatGPT's Micro Cap Portfolio vs. S&P 500")
+    plt.title(f"ChatGPT's Micro Cap Portfolio vs. {benchmark_index}")
     plt.xlabel("Date")
     plt.ylabel("Value of $100 Investment")
     plt.xticks(rotation=15)
@@ -130,10 +136,16 @@ if __name__ == "__main__":
         type=str,
         help="End date for the chart (YYYY-MM-DD)",
     )
+    parser.add_argument(
+        "--benchmark-index",
+        type=str,
+        default="^SPX",
+        help="Ticker for comparison index (e.g. ^AXJO)",
+    )
     args = parser.parse_args()
 
     start = pd.to_datetime(args.start_date) if args.start_date else None
     end = pd.to_datetime(args.end_date) if args.end_date else None
 
-    main(args.baseline_equity, start, end)
+    main(args.baseline_equity, start, end, args.benchmark_index)
 

--- a/Start Your Own/Trading_Script.py
+++ b/Start Your Own/Trading_Script.py
@@ -13,6 +13,11 @@ import pandas as pd
 import yfinance as yf
 from typing import cast
 
+# Regional defaults
+# Set ``DEFAULT_SUFFIX`` to ".AX" when working with Australian tickers
+DEFAULT_SUFFIX = ""
+DEFAULT_BENCHMARKS = ["^RUT", "IWO", "XBI"]
+
 # Shared file locations
 DATA_DIR = "Start Your Own"
 PORTFOLIO_CSV = f"{DATA_DIR}/chatgpt_portfolio_update.csv"
@@ -20,6 +25,13 @@ TRADE_LOG_CSV = f"{DATA_DIR}/chatgpt_trade_log.csv"
 
 # Today's date reused across logs
 today = datetime.today().strftime("%Y-%m-%d")
+
+
+def apply_suffix(ticker: str) -> str:
+    """Append ``DEFAULT_SUFFIX`` when the ticker lacks an exchange suffix."""
+    if DEFAULT_SUFFIX and "." not in ticker and not ticker.startswith("^"):
+        return f"{ticker}{DEFAULT_SUFFIX}"
+    return ticker
 
 
 def process_portfolio(portfolio: pd.DataFrame, starting_cash: float) -> pd.DataFrame:
@@ -41,7 +53,7 @@ def process_portfolio(portfolio: pd.DataFrame, starting_cash: float) -> pd.DataF
         ).strip().lower()
         if action == "b":
             try:
-                ticker = input("Enter ticker symbol: ").strip().upper()
+                ticker = apply_suffix(input("Enter ticker symbol: ").strip().upper())
                 shares = float(input("Enter number of shares: "))
                 buy_price = float(input("Enter buy price: "))
                 stop_loss = float(input("Enter stop loss: "))
@@ -56,7 +68,7 @@ def process_portfolio(portfolio: pd.DataFrame, starting_cash: float) -> pd.DataF
             continue
         if action == "s":
             try:
-                ticker = input("Enter ticker symbol: ").strip().upper()
+                ticker = apply_suffix(input("Enter ticker symbol: ").strip().upper())
                 shares = float(input("Enter number of shares to sell: "))
                 sell_price = float(input("Enter sell price: "))
                 if shares <= 0 or sell_price <= 0:
@@ -71,7 +83,7 @@ def process_portfolio(portfolio: pd.DataFrame, starting_cash: float) -> pd.DataF
         break
 
     for _, stock in portfolio.iterrows():
-        ticker = stock["ticker"]
+        ticker = apply_suffix(stock["ticker"])
         shares = int(stock["shares"])
         cost = stock["buy_price"]
         stop = stock["stop_loss"]
@@ -297,12 +309,20 @@ def log_manual_sell(
     return cash, chatgpt_portfolio
 
 
-def daily_results(chatgpt_portfolio: pd.DataFrame, cash: float) -> None:
+def daily_results(
+    chatgpt_portfolio: pd.DataFrame,
+    cash: float,
+    benchmarks: list[str] | None = None,
+    rf_annual: float = 0.045,
+    comparison_index: str = "^SPX",
+) -> None:
     """Print daily price updates and performance metrics."""
     if isinstance(chatgpt_portfolio, pd.DataFrame):
         portfolio_dict = chatgpt_portfolio.to_dict(orient="records")
+    if benchmarks is None:
+        benchmarks = DEFAULT_BENCHMARKS
     print(f"prices and updates for {today}")
-    for stock in portfolio_dict + [{"ticker": "^RUT"}] + [{"ticker": "IWO"}] + [{"ticker": "XBI"}]:
+    for stock in portfolio_dict + [{"ticker": b} for b in benchmarks]:
         ticker = stock["ticker"]
         try:
             data = yf.download(ticker, period="2d", progress=False)
@@ -338,8 +358,7 @@ def daily_results(chatgpt_portfolio: pd.DataFrame, cash: float) -> None:
     # Number of total trading days
     n_days = len(chatgpt_totals)
 
-    # Risk-free return over total trading period (assuming 4.5% risk-free rate)
-    rf_annual = 0.045
+    # Risk-free return over total trading period
     rf_period = (1 + rf_annual) ** (n_days / 252) - 1
 
     # Standard deviation of daily returns
@@ -355,17 +374,24 @@ def daily_results(chatgpt_portfolio: pd.DataFrame, cash: float) -> None:
     print(f"Total Sharpe Ratio over {n_days} days: {sharpe_total:.4f}")
     print(f"Total Sortino Ratio over {n_days} days: {sortino_total:.4f}")
     print(f"Latest ChatGPT Equity: ${final_equity:.2f}")
-    # Get S&P 500 data
-    spx = yf.download("^SPX", start="2025-06-27", end=final_date + pd.Timedelta(days=1), progress=False)
-    spx = cast(pd.DataFrame, spx)
-    spx = spx.reset_index()
+
+    # Get comparison index data
+    start_date = chatgpt_totals["Date"].min()
+    index_df = yf.download(
+        comparison_index,
+        start=start_date,
+        end=final_date + pd.Timedelta(days=1),
+        progress=False,
+    )
+    index_df = cast(pd.DataFrame, index_df)
+    index_df = index_df.reset_index()
 
     # Normalize to $100
-    initial_price = spx["Close"].iloc[0].item()
-    price_now = spx["Close"].iloc[-1].item()
+    initial_price = index_df["Close"].iloc[0].item()
+    price_now = index_df["Close"].iloc[-1].item()
     scaling_factor = 100 / initial_price
-    spx_value = price_now * scaling_factor
-    print(f"$100 Invested in the S&P 500: ${spx_value:.2f}")
+    index_value = price_now * scaling_factor
+    print(f"$100 Invested in {comparison_index}: ${index_value:.2f}")
     print(f"today's portfolio: {chatgpt_portfolio}")
     print(f"cash balance: {cash}")
 


### PR DESCRIPTION
## Summary
- allow configurable benchmarks, risk-free rate, and index in trading scripts
- append regional suffixes like .AX to tickers automatically
- support custom benchmark index in graph generator and document ASX usage

## Testing
- `python -m py_compile 'Scripts and CSV Files/Trading_Script.py' 'Start Your Own/Trading_Script.py' 'Start Your Own/Generate_Graph.py'`
- `python 'Start Your Own/Generate_Graph.py' --help`


------
https://chatgpt.com/codex/tasks/task_e_6895595e2158832e965fd06fff44e403